### PR TITLE
ci: push compressed build directory

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -42,10 +42,13 @@ pipeline {
         sshagent(credentials: ['status-im-auto-ssh']) {
           script {
             nix.develop("""
+              mkdir -p temp_out
+              tar -xzf out.tar.gz -C temp_out --strip-components=1
               ghp-import \
                 -b ${deployBranch()} \
                 -c ${deployDomain()} \
-                -p out
+                -p temp_out
+              rm -rf temp_out
             """, pure: false)
           }
         }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "type": "module",
   "scripts": {
     "dev": "next dev",
-    "build": "next build",
+    "build": "next build && tar -czf out.tar.gz out/",
+    "build:clean": "rm -rf out out.tar.gz && next build && tar -czf out.tar.gz out/",
     "start": "next start",
     "lint": "next lint",
     "prepare": "husky install"


### PR DESCRIPTION
## Description:

In CI when we build and push this repo we currently create a `610MB` build folder called `out`.

```
siddarthkumar in ~/code/acid-info/logos-ordinals-dashboard on master λ du -sh out                                                                                  
610M    out
```
Jenkins will copy these artefacts to either `deploy-develop` or `deploy-master` (depending on stage)
Then the github `webhook` will be triggered and our `Caddy` Server will pull these changes.

This takes more than 20 seconds resulting in `webhook` timeouts.

In this PR we will Tarball the `out` directory as part of build step use that compressed tar file to deploy on our Caddy server.
```
siddarthkumar in ~/code/acid-info/logos-ordinals-dashboard on master λ du -sh out.tar.gz                                                                          
 97M    out.tar.gz
```
This tarball will then be extracted by caddy like this : 

```
        git {
                repo repo {
                        base_dir /var/lib/caddy-git/dev-dashboard.logos.co/
                        url https://github.com/acid-info/logos-ordinals-dashboard.git
                        branch deploy-develop
                        depth 1
                        webhook Github X-Hub-Signature-256 $secret
                        post pull exec {
                          name ExtractTar
                          command tar
                          args -xzf out.tar.gz -C {base_dir}/repo
                        }
                        post pull exec {
                          name Cleanup
                          command rm
                          args {base_dir}/repo/out.tar.gz
                        }
                }
        }
```

This should speed things up and we may avoid timeouts.
We should test this first on `dev-dashboard.logos.co` and then on `dashboard.logos.co`
